### PR TITLE
Add multiline@1.0.2 to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/alsotang/fast-js#readme",
   "dependencies": {
     "lodash": "3.10.1",
-    "matcha": "0.6.0"
+    "matcha": "0.6.0",
+    "multiline": "1.0.2"
   }
 }


### PR DESCRIPTION
Fixes error when running

```
› npm install
› make build
module.js:338
    throw err;
    ^

Error: Cannot find module 'multiline'
```
